### PR TITLE
Closes #18 - Role specific notifications about upcoming events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ credentials.json
 token.json
 reminderchannel.json
 
+# Logs
+bot_logs.txt
+
 # C extensions
 *.so
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # Google calendar stuff
 credentials.json
 token.json
+reminderchannel.json
 
 # C extensions
 *.so

--- a/discordbot/api/google_calendar_api.py
+++ b/discordbot/api/google_calendar_api.py
@@ -45,7 +45,7 @@ class GoogleCalendarAPI:
             print(f"Google calendar initialization failed: {error}")
             return None
 
-    def list_events(self, max_results=10):
+    def get_events(self, max_results=10):
         try:
             # Call the Calendar API
             now = datetime.utcnow().isoformat() + "Z"  # 'Z' indicates UTC time
@@ -64,31 +64,7 @@ class GoogleCalendarAPI:
             )
             events = events_result.get("items", [])
 
-            if not events:
-                return "No upcoming events found."
-
-            # Sends the start and name of the next events_num events
-            payload = ""
-            for event in events:
-                # Get event start time
-                start = event["start"].get(
-                    "dateTime", event["start"].get("date"))
-                # Convert to human readable format
-                start_dt = datetime.fromisoformat(start)
-                formatted_start = start_dt.strftime(
-                    "%B %d, %Y, %I:%M %p").lstrip("0").replace(" 0", " ")
-
-                # # Get tags, if available
-                # tags_json = event.get('extendedProperties', {}).get(
-                #     'private', {}).get('tags', '')
-                # tags = json.loads(tags_json) if tags_json else []
-
-                # # Format tags for display
-                # tags_str = ", ".join(tags) if tags else "No Tags"
-
-                payload += f"**{formatted_start}:** {event['summary']}\n"
-
-            return payload
+            return events
 
         except HttpError as error:
             return f"An error occured: {error}"

--- a/discordbot/api/google_calendar_api.py
+++ b/discordbot/api/google_calendar_api.py
@@ -1,12 +1,13 @@
-import os
 import json
+import os
+from datetime import datetime
+
+from dotenv import load_dotenv
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from datetime import datetime
-from dotenv import load_dotenv
 
 load_dotenv()
 TIMEZONE = os.environ['TIMEZONE']
@@ -15,6 +16,7 @@ SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
 
 class GoogleCalendarAPI:
+
     def __init__(self):
         self.service = self.initialize_service()
 
@@ -47,7 +49,6 @@ class GoogleCalendarAPI:
 
     def get_events(self, max_results=10):
         try:
-            # Call the Calendar API
             now = datetime.utcnow().isoformat() + "Z"  # 'Z' indicates UTC time
 
             # Getting the upcoming max_results events
@@ -71,10 +72,9 @@ class GoogleCalendarAPI:
 
     def get_remindable_events(self):
         try:
-            # Call the Calendar API
-            now = datetime.utcnow().isoformat() + "Z"  # 'Z' indicates UTC time
+            now = datetime.utcnow().isoformat() + "Z"
 
-            # Getting the upcoming max_results events
+            # Getting all remindable events
             events_result = (
                 self.service.events()
                 .list(
@@ -95,10 +95,10 @@ class GoogleCalendarAPI:
 
     def create_event(self, summary, location, description, start_time: datetime, end_time: datetime, roles: list = None, mins_before_reminder: list = None):
         # Example arguments:
-        # Test event, University of Alberta, Description, datetime start time, datetime end time, ["tag1"]
+        # Test event, University of Alberta, Description, datetime start time, datetime end time, ["role1"], [120, 60, 30, 5]
 
         if not summary or not start_time or not end_time:
-            return None
+            return "Error: Cannot create event without summary, start_time or end_time"
 
         # Convert additional data to json
         roles_json = json.dumps(roles) if roles is not None else ''

--- a/discordbot/api/google_calendar_api.py
+++ b/discordbot/api/google_calendar_api.py
@@ -1,7 +1,6 @@
 import json
 import os
-from datetime import datetime
-
+from datetime import datetime, timedelta
 from dotenv import load_dotenv
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -47,51 +46,37 @@ class GoogleCalendarAPI:
             print(f"Google calendar initialization failed: {error}")
             return None
 
-    def get_events(self, max_results=10):
+    def get_events(self, max_results=10, custom_reminders=False):
         try:
             now = datetime.utcnow().isoformat() + "Z"  # 'Z' indicates UTC time
+            query_params = {
+                "calendarId": "primary",
+                "timeMin": now,
+                "singleEvents": True,
+                "orderBy": "startTime",
+            }
 
-            # Getting the upcoming max_results events
-            events_result = (
-                self.service.events()
-                .list(
-                    calendarId="primary",
-                    timeMin=now,
-                    maxResults=max_results,
-                    singleEvents=True,
-                    orderBy="startTime"
-                )
-                .execute()
-            )
+            if max_results is not None:
+                query_params["maxResults"] = max_results
+
+            if custom_reminders is True:
+                # Currently, the earliest custom reminder for an event is 1 week
+                # So when googlecalendar.py calls this to find events that need a reminder scheduled
+                # We do not care about anything past that point
+                one_week_from_now = datetime.utcnow() + timedelta(weeks=1, hours=1)
+                one_week_from_now_iso = one_week_from_now.isoformat() + "Z"
+                query_params["timeMax"] = one_week_from_now_iso
+
+                custom_reminders_val = "true" if custom_reminders else "false"
+                query_params["privateExtendedProperty"] = f"custom={custom_reminders_val}"
+
+            events_result = self.service.events().list(**query_params).execute()
             events = events_result.get("items", [])
 
             return events
 
         except HttpError as error:
-            return f"An error occured: {error}"
-
-    def get_remindable_events(self):
-        try:
-            now = datetime.utcnow().isoformat() + "Z"
-
-            # Getting all remindable events
-            events_result = (
-                self.service.events()
-                .list(
-                    calendarId="primary",
-                    timeMin=now,
-                    singleEvents=True,
-                    orderBy="startTime",
-                    privateExtendedProperty="remindable=true"
-                )
-                .execute()
-            )
-            events = events_result.get("items", [])
-
-            return events
-
-        except HttpError as error:
-            return f"An error occured: {error}"
+            return f"An error occurred: {error}"
 
     def create_event(self, summary, location, description, start_time: datetime, end_time: datetime, roles: list = None, mins_before_reminder: list = None):
         # Example arguments:
@@ -103,7 +88,7 @@ class GoogleCalendarAPI:
         # Convert additional data to json
         roles_json = json.dumps(roles) if roles is not None else ''
         minutes_list_json = json.dumps(mins_before_reminder) if mins_before_reminder is not None else ''
-        remindable = "true" if mins_before_reminder is not None else 'false'
+        is_custom = "true" if mins_before_reminder is not None else 'false'
 
         # mins_before_reminder is a list of integers which represent minutes
         # mins_before_reminder = [60, 30, 15] means: remind about this event 60 minutes before it happens, 30, 15 minutes.
@@ -131,7 +116,7 @@ class GoogleCalendarAPI:
                 'private': {
                     'roles': roles_json,  # Roles to remind
                     'reminderMinutes': minutes_list_json,
-                    'remindable': remindable
+                    'custom': is_custom
                 }
             }
         }

--- a/discordbot/cogs/googlecalendar.py
+++ b/discordbot/cogs/googlecalendar.py
@@ -22,8 +22,9 @@ class Calendar(commands.Cog):
         self.guild = None
         # Default time before event to send reminder
         self.reminder_time_before = timedelta(hours=2)
+        self.notified_events = set()
         self.check_events.start()
-    
+
     def get_event_mentions(self, event):
         # Get roles, if available (stored in tags property)
         roles_json = event.get('extendedProperties', {}).get(
@@ -43,12 +44,15 @@ class Calendar(commands.Cog):
         start_formatted = start_dt.strftime(
             "%B %d, %Y, %I:%M %p").lstrip("0").replace(" 0", " ")
 
-        embed = discord.Embed(title=f"Reminder:\n**{summary}** is starting soon!", color=discord.Color.random())
+        embed = discord.Embed(
+            title=f"Reminder:\n**{summary}** is starting soon!", color=discord.Color.random())
 
-        embed.add_field(name="Start time:", value=f"**{start_formatted}**", inline=False)
+        embed.add_field(name="Start time:",
+                        value=f"**{start_formatted}**", inline=False)
 
         if description:
-            embed.add_field(name="Description:", value=description, inline=False)
+            embed.add_field(name="Description:",
+                            value=description, inline=False)
         if location:
             embed.add_field(name="Location:", value=location, inline=False)
 
@@ -69,8 +73,10 @@ class Calendar(commands.Cog):
             start_iso = event["start"].get(
                 "dateTime", event["start"].get("date"))
             start = datetime.fromisoformat(start_iso)
+            id = event.get("id")
 
-            if now + self.reminder_time_before >= start:
+            if now + self.reminder_time_before >= start and (id not in self.notified_events):
+                self.notified_events.add(id)
                 await self.reminder_channel.send(content=self.get_event_mentions(event), embed=self.get_reminder_embed(event, start))
 
     @check_events.before_loop

--- a/discordbot/cogs/googlecalendar.py
+++ b/discordbot/cogs/googlecalendar.py
@@ -21,7 +21,7 @@ class Calendar(commands.Cog):
         self.reminder_channel = None  # Set this via a command
         self.guild = None
         # Default time before event to send reminder
-        self.reminder_time_before = timedelta(hours=2)
+        self.reminder_time_before = timedelta(hours=5)
         self.notified_events = set()
         self.check_events.start()
 
@@ -98,11 +98,12 @@ class Calendar(commands.Cog):
     @commands.command()
     @commands.has_permissions(administrator=True)
     async def setremindertime(self, ctx, hours_before: int):
+        
         if (hours_before < 1):
             await ctx.send("Invalid reminder time.")
             return
 
-        self.reminder_time_before = datetime.timedelta(hours=hours_before)
+        self.reminder_time_before = timedelta(hours=hours_before)
         await ctx.send(f"Reminders will be sent {hours_before} hours before events.")
 
     @commands.command(brief='Opens event creation menu', aliases=['pl'])
@@ -130,8 +131,10 @@ class Calendar(commands.Cog):
 
         # Get event data
         event_data = event_creation_view.event_data
+        roles_to_remind = event_creation_view.selected_roles
+
         response = self.google_calendar.create_event(event_data.get("summary"), event_data.get("location"),
-                                                     event_data.get("description"), event_data.get("start_time"), event_data.get("end_time"), tags=event_data.get("tags"))
+                                                     event_data.get("description"), event_data.get("start_time"), event_data.get("end_time"), tags=roles_to_remind)
 
         await ctx.send(content=response)
 

--- a/discordbot/cogs/googlecalendar.py
+++ b/discordbot/cogs/googlecalendar.py
@@ -1,21 +1,21 @@
-import os
 import json
-import pytz
+import os
+from datetime import datetime, timedelta
+
 import discord
+import pytz
+from discord.ext import commands, tasks
+from dotenv import load_dotenv
+
 from api.google_calendar_api import GoogleCalendarAPI
 from views.event_creation_view import EventCreationView
-from discord.ext import commands, tasks
-from datetime import datetime, timedelta
-from dotenv import load_dotenv
 
 load_dotenv()
 TIMEZONE = os.environ['TIMEZONE']
 
 
 def get_event_mentions(event, guild: discord.Guild):
-    # Get roles, if available (stored in tags property)
-    roles_json = event.get('extendedProperties', {}).get(
-        'private', {}).get('roles', '')
+    roles_json = event.get('extendedProperties', {}).get('private', {}).get('roles', '')
     roles = json.loads(roles_json) if roles_json else None
 
     if roles is None:
@@ -32,8 +32,7 @@ def get_reminder_embed(event, start_dt: datetime):
     description = event.get('description')
     location = event.get('location')
 
-    start_formatted = start_dt.strftime(
-        "%B %d, %Y, %I:%M %p").lstrip("0").replace(" 0", " ")
+    start_formatted = start_dt.strftime("%B %d, %Y, %I:%M %p").lstrip("0").replace(" 0", " ")
 
     now = datetime.now(start_dt.tzinfo)
     time_diff = start_dt - now
@@ -46,13 +45,14 @@ def get_reminder_embed(event, start_dt: datetime):
 
     if hrs_left == 0:
         title = f"Reminder:\n**{summary}** starts in **{mins_left}** {minutes}!"
+    elif mins_left == 0:
+        title = f"Reminder:\n**{summary}** starts in **{hrs_left}** {hours}!"
     else:
         title = f"Reminder:\n**{summary}** starts in **{hrs_left}** {hours} **{mins_left}** {minutes}!"
 
     embed = discord.Embed(title=title, color=discord.Color.random())
 
-    embed.add_field(name="Start time:",
-                    value=f"**{start_formatted}**", inline=False)
+    embed.add_field(name="Start time:", value=f"**{start_formatted}**", inline=False)
 
     if description:
         embed.add_field(name="Description:", value=description, inline=False)
@@ -70,7 +70,7 @@ class Calendar(commands.Cog):
         self.active_menus = set()
         # Set this via a command
         self.reminder_channel_id = None
-        # Remembering values above
+        # Remembering value above
         self.settings_file = 'reminderchannel.json'
         self.load_settings()
         self.event_reminders.start()
@@ -97,7 +97,6 @@ class Calendar(commands.Cog):
 
     @tasks.loop(minutes=1)
     async def event_reminders(self):
-
         reminder_channel = self.bot.get_channel(self.reminder_channel_id)
         if reminder_channel is None:
             return
@@ -118,16 +117,18 @@ class Calendar(commands.Cog):
 
             for minute_offset in minute_offsets:
                 reminder_time = start - timedelta(minutes=minute_offset)
+
                 # Check if 'now' is within 1 minute of the reminder time
                 if 0 <= (reminder_time - now).total_seconds() < 60:
-                    await reminder_channel.send(content=get_event_mentions(event, reminder_channel.guild), embed=get_reminder_embed(event, start))
+                    await reminder_channel.send(content=get_event_mentions(event, reminder_channel.guild),
+                                                embed=get_reminder_embed(event, start))
                     break
 
     @event_reminders.before_loop
     async def before_event_reminders(self):
         await self.bot.wait_until_ready()
 
-    @commands.command()
+    @commands.command(brief='Call with 1 argument: channel id')
     @commands.has_permissions(administrator=True)
     async def setreminderchannel(self, ctx, channel_id: int):
         channel = self.bot.get_channel(channel_id)
@@ -139,20 +140,9 @@ class Calendar(commands.Cog):
         self.save_settings()
         await ctx.send(f"Reminder channel is now <#{channel_id}>. Saved to a json file for persistency.")
 
-    @commands.command()
-    @commands.has_permissions(administrator=True)
-    async def setremindertime(self, ctx, hours_before: int):
-        if (hours_before < 1 or hours_before > 500):
-            await ctx.send("Invalid reminder time. Must be int in [1, 500]")
-            return
-
-        self.reminder_time_before = timedelta(hours=hours_before)
-        await ctx.send(f"Reminders will be sent {hours_before} hours before events.")
-
     @commands.command(brief='Opens event creation menu', aliases=['pl'])
     @commands.has_permissions(administrator=True)
     async def plan(self, ctx):
-        # Check if the user already has an active menu
         if ctx.author.id in self.active_menus:
             await ctx.send("You already have an active event creation menu.")
             return
@@ -161,7 +151,6 @@ class Calendar(commands.Cog):
         event_creation_view = EventCreationView(user=ctx.author)
         msg = await ctx.send(content="**Event creation menu:**", view=event_creation_view)
 
-        # Add the user to the set of active menus
         self.active_menus.add(ctx.author.id)
 
         # Wait until it finishes execution and notify user if it times out
@@ -183,39 +172,7 @@ class Calendar(commands.Cog):
 
         await ctx.send(content=response)
 
-    @commands.command(brief='Plans an event from one text command call. Call without arguments to see format', aliases=['plc', 'planc', 'plcli'])
-    @commands.has_permissions(administrator=True)
-    async def plancli(self, ctx, *, payload=""):
-        if not payload:
-            line_1 = r'!plancli Summary;Location;Description;Start time: %d/%m/%Y %H:%M:%S;End time: %d/%m/%Y %H:%M:%S;role1, role2, ...'
-            line_2 = '!plancli Test event;University of Alberta;Description;20/11/2024 09:15:30;20/11/2024 10:00:00; role1, role2'
-
-            await ctx.send(content=line_1+"\ne.g.\n"+line_2)
-            return
-
-        argument_list = payload.split(';')
-
-        if (len(argument_list) != 5) and (len(argument_list) != 6):
-            await ctx.send(content="Invalid number of arguments. Call !plancli without arguments to see proper format example")
-            return
-
-        tags = argument_list[5].strip().split(
-            ',') if len(argument_list) > 5 else None
-
-        try:
-            start_time = datetime.strptime(
-                argument_list[3], "%d/%m/%Y %H:%M:%S")
-            end_time = datetime.strptime(argument_list[4], "%d/%m/%Y %H:%M:%S")
-        except ValueError:
-            await ctx.send(content="Could not convert start_time or end_time to datetime object")
-            return
-
-        response = self.google_calendar.create_event(
-            argument_list[0], argument_list[1], argument_list[2], start_time, end_time, tags)
-
-        await ctx.send(content=response)
-
-    @commands.command(brief='Lists 10 (or specified number of) upcoming Google Calendar events', aliases=['calendar', 'ev'])
+    @commands.command(brief='Lists 10 (or specified number of) upcoming events', aliases=['calendar', 'ev'])
     async def events(self, ctx, events_num=10):
         if (events_num < 1) or (events_num > 30):
             await ctx.send(content="Invalid number of events provided. Must be int and in [1, 30]")
@@ -233,8 +190,7 @@ class Calendar(commands.Cog):
 
             # Convert to human readable format
             start_dt = datetime.fromisoformat(start)
-            formatted_start = start_dt.strftime(
-                "%B %d, %Y, %I:%M %p").lstrip("0").replace(" 0", " ")
+            formatted_start = start_dt.strftime("%B %d, %Y, %I:%M %p").lstrip("0").replace(" 0", " ")
 
             output += f"**{formatted_start}:** {event['summary']}\n"
 

--- a/discordbot/cogs/googlecalendar.py
+++ b/discordbot/cogs/googlecalendar.py
@@ -38,13 +38,16 @@ def get_reminder_embed(event, start_dt: datetime):
     # adding one minute so reminder doesn't say "event starts in 59 minutes, 29 minutes"
     time_diff = start_dt - now + timedelta(minutes=1)
 
-    hrs_left = int(time_diff.total_seconds() / 3600)
+    days_left = int(time_diff.total_seconds() / 86400)
+    days = f"day{'s' if days_left != 1 else ''}"
+    hrs_left = int(time_diff.total_seconds() / 3600) - (days_left * 24)
     hours = f"hour{'s' if hrs_left != 1 else ''}"
-
     mins_left = int(time_diff.total_seconds() / 60) - (hrs_left * 60)
     minutes = f"minute{'s' if mins_left != 1 else ''}"
 
-    if hrs_left == 0:
+    if days_left > 0:
+        title = f"Reminder:\n**{summary}** starts in **{days_left}** {days}!"
+    elif hrs_left == 0:
         title = f"Reminder:\n**{summary}** starts in **{mins_left}** {minutes}!"
     elif mins_left == 0:
         title = f"Reminder:\n**{summary}** starts in **{hrs_left}** {hours}!"

--- a/discordbot/cogs/googlecalendar.py
+++ b/discordbot/cogs/googlecalendar.py
@@ -26,6 +26,9 @@ class Calendar(commands.Cog):
         self.reminded_events = set()
         self.event_reminders.start()
 
+    def cog_unload(self):
+        self.event_reminders.cancel()
+
     def get_event_mentions(self, event):
         # Get roles, if available (stored in tags property)
         roles_json = event.get('extendedProperties', {}).get('private', {}).get('tags', '')
@@ -109,8 +112,8 @@ class Calendar(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def setremindertime(self, ctx, hours_before: int):
         
-        if (hours_before < 1):
-            await ctx.send("Invalid reminder time.")
+        if (hours_before < 1 or hours_before > 500):
+            await ctx.send("Invalid reminder time. Must be int in [1, 500]")
             return
 
         self.reminder_time_before = timedelta(hours=hours_before)

--- a/discordbot/cogs/googlecalendar.py
+++ b/discordbot/cogs/googlecalendar.py
@@ -39,9 +39,10 @@ class Calendar(commands.Cog):
         summary = event.get('summary')
         start_formatted = start_dt.strftime(
             "%B %d, %Y, %I:%M %p").lstrip("0").replace(" 0", " ")
-        message = f"{roles_mention}\nReminder: **{summary}** is starting soon!\n\nStart time: **{start_formatted}**"
 
-        return message
+        output = f"{roles_mention}\nReminder: **{summary}** is starting soon!\nStart time: **{start_formatted}**"
+
+        return output
 
     @tasks.loop(minutes=10)
     async def check_events(self):
@@ -63,7 +64,6 @@ class Calendar(commands.Cog):
             start_dt = datetime.fromisoformat(start)
 
             if now + self.reminder_time_before >= start_dt:
-                # Send a reminder
                 await reminder_channel.send(self.get_event_reminder(event, start_dt))
 
     @check_events.before_loop

--- a/discordbot/views/default_reminders_view.py
+++ b/discordbot/views/default_reminders_view.py
@@ -1,0 +1,46 @@
+import discord
+
+select_offsets = [
+    discord.SelectOption(label="1 week before", value="10080"),
+    discord.SelectOption(label="3 days before", value="4320"),
+    discord.SelectOption(label="1 day before", value="1440"),
+    discord.SelectOption(label="12 hours before", value="720"),
+    discord.SelectOption(label="6 hours before", value="360"),
+    discord.SelectOption(label="3 hours before", value="180"),
+    discord.SelectOption(label="1 hour before", value="60"),
+    discord.SelectOption(label="30 minutes before", value="30"),
+    discord.SelectOption(label="15 minutes before", value="15"),
+    discord.SelectOption(label="5 minutes before", value="5"),
+]
+
+
+class DefaultRemindersView(discord.ui.View):
+
+    def __init__(self, user: discord.User):
+        super().__init__(timeout=1800)
+        self.user = user
+        self.minute_offsets = None
+        self.offsets_submitted = False
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """
+        Only the user passed to constructor can use this view
+        """
+        return interaction.user == self.user
+
+    @discord.ui.button(label="Submit", emoji="✅", style=discord.ButtonStyle.grey, disabled=True, row=0)
+    async def submit(self, interaction: discord.Interaction, button: discord.ui.Button):
+        # Clear items, respond to interaction, and stop
+        self.clear_items()
+        await interaction.response.defer()
+        await interaction.delete_original_response()
+        self.stop()
+
+    @discord.ui.select(cls=discord.ui.Select, placeholder='Custom remind times (default=1d, 3h, 15m)', options=select_offsets, min_values=0, max_values=10, row=1)
+    async def select_remind_times(self, interaction: discord.Interaction, select: discord.ui.Select):
+        self.minute_offsets = [int(value) for value in select.values]
+        self.offsets_submitted = True
+        submit_button = self.children[0]
+        submit_button.disabled = False
+        submit_button.style = discord.ButtonStyle.green
+        await interaction.response.edit_message(view=self, content=f'**You selected offsets (in minutes):** {", ".join(select.values)}')

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -132,6 +132,13 @@ def return_valid_duration(duration: str):
     return duration_minutes if duration_minutes > 0 else False
 
 
+SELECT_OPTIONS = [
+    discord.SelectOption(label='Role0', value = "0"),
+    discord.SelectOption(label='Role1', value = "1"),
+    discord.SelectOption(label='Role2', value = "2")
+]
+
+
 class EventCreationView(discord.ui.View):
 
     def __init__(self, user: discord.User):
@@ -149,6 +156,7 @@ class EventCreationView(discord.ui.View):
             "start_time": "",
             "end_time": ""
         }
+        self.selected_roles=None
         self.name_modal_submitted = False
         self.date_modal_submitted = False
 
@@ -219,7 +227,7 @@ class EventCreationView(discord.ui.View):
 
         return error_payload
 
-    @discord.ui.button(label="Set Title", emoji="✏️", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="Set Title", emoji="✏️", style=discord.ButtonStyle.primary, row=0)
     async def set_title(self, interaction: discord.Interaction, button: discord.ui.Button):
         # On click, create the modal and send it to the user
         modal = EventNamingModal(
@@ -242,7 +250,7 @@ class EventCreationView(discord.ui.View):
         button.style = discord.ButtonStyle.gray
         await self.check_readiness(interaction)
 
-    @discord.ui.button(label="Set Date", emoji="📅", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="Set Date", emoji="📅", style=discord.ButtonStyle.primary, row=0)
     async def set_date(self, interaction: discord.Interaction, button: discord.ui.Button):
         # On click, create the modal and send it to the user
         modal = EventDateModal(
@@ -269,10 +277,15 @@ class EventCreationView(discord.ui.View):
         button.style = discord.ButtonStyle.gray
         await self.check_readiness(interaction)
 
-    @discord.ui.button(label="Submit", emoji="✅", style=discord.ButtonStyle.grey, disabled=True)
+    @discord.ui.button(label="Submit", emoji="✅", style=discord.ButtonStyle.grey, disabled=True, row=0)
     async def submit(self, interaction: discord.Interaction, button: discord.ui.Button):
         # Clear items, respond to interaction, and stop
         self.clear_items()
         await interaction.response.defer()
         await interaction.delete_original_response()
         self.stop()
+
+    @discord.ui.select(cls=discord.ui.RoleSelect, placeholder='Roles to ping', min_values=0, max_values=25, row=1)
+    async def select_roles(self, interaction: discord.Interaction, select: discord.ui.RoleSelect):
+        self.selected_roles=[role.name for role in select.values]
+        await interaction.response.edit_message(view=self, content=f'**You selected roles:** {", ".join(self.selected_roles)}')

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -209,8 +209,8 @@ class EventCreationView(discord.ui.View):
             end_time = start_time + timedelta(minutes=duration_minutes)
 
             # Prepare event information
-            self.event_data["start_time"] = start_time.isoformat()
-            self.event_data["end_time"] = end_time.isoformat()
+            self.event_data["start_time"] = start_time
+            self.event_data["end_time"] = end_time
 
         return error_payload
 

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -15,8 +15,8 @@ class EventNamingModal(discord.ui.Modal, title="Name The Event"):
         label="Title",
         required=True,
         placeholder="Event Summary",
-        # This is 200 because a title of a reminder embed can only be 256 characters
-        # And the format I use for the title is title=f"Reminder:\n**{summary}** starts in **{before_start}** {unit}!"
+        # This is 200 because a title of a reminder embed (in googlecalendar.py) can only be 256 characters
+        # And the format used for the title of the reminder embed is not just the summary
         max_length=200
     )
 

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -15,9 +15,9 @@ class EventNamingModal(discord.ui.Modal, title="Name The Event"):
         label="Title",
         required=True,
         placeholder="Event Summary",
-        # This is 224 because a title of a reminder embed can only be 256 characters
-        # And the format I use for the title is title=f"Reminder:\n**{summary}** is starting soon!"
-        max_length=224
+        # This is 200 because a title of a reminder embed can only be 256 characters
+        # And the format I use for the title is title=f"Reminder:\n**{summary}** starts in **{before_start}** {unit}!"
+        max_length=200
     )
 
     description = discord.ui.TextInput(

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -14,21 +14,26 @@ class EventNamingModal(discord.ui.Modal, title="Name The Event"):
         style=discord.TextStyle.short,
         label="Title",
         required=True,
-        placeholder="Event Summary"
+        placeholder="Event Summary",
+        # This is 224 because a title of a reminder embed can only be 256 characters
+        # And the format I use for the title is title=f"Reminder:\n**{summary}** is starting soon!"
+        max_length=224
     )
 
     description = discord.ui.TextInput(
         style=discord.TextStyle.long,
         label="Description",
         required=False,
-        placeholder="Event Description (optional)"
+        placeholder="Event Description (optional)",
+        max_length=1024
     )
 
     location = discord.ui.TextInput(
         style=discord.TextStyle.short,
         label="Location",
         required=False,
-        placeholder="Event Location (optional)"
+        placeholder="Event Location (optional)",
+        max_length=1024
     )
 
     async def on_submit(self, interaction: discord.Interaction) -> None:

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -133,16 +133,16 @@ def return_valid_duration(duration: str):
 
 
 select_offsets = [
-            discord.SelectOption(label="1 week before", value="10080"),  # 168 hours * 60 minutes
-            discord.SelectOption(label="3 days before", value="4320"),   # 72 hours * 60 minutes
-            discord.SelectOption(label="1 day before", value="1440"),    # 24 hours * 60 minutes
-            discord.SelectOption(label="12 hours before", value="720"),  # 12 hours * 60 minutes
-            discord.SelectOption(label="6 hours before", value="360"),   # 6 hours * 60 minutes
-            discord.SelectOption(label="3 hours before", value="180"),   # 3 hours * 60 minutes
-            discord.SelectOption(label="1 hour before", value="60"),     # 1 hour * 60 minutes
-            discord.SelectOption(label="30 minutes before", value="30"), # 30 minutes
-            discord.SelectOption(label="15 minutes before", value="15"), # 15 minutes
-            discord.SelectOption(label="5 minutes before", value="5"),   # 5 minutes
+            discord.SelectOption(label="1 week before", value="10080"),
+            discord.SelectOption(label="3 days before", value="4320"),
+            discord.SelectOption(label="1 day before", value="1440"),
+            discord.SelectOption(label="12 hours before", value="720"),
+            discord.SelectOption(label="6 hours before", value="360"),
+            discord.SelectOption(label="3 hours before", value="180"),
+            discord.SelectOption(label="1 hour before", value="60"),
+            discord.SelectOption(label="30 minutes before", value="30"),
+            discord.SelectOption(label="15 minutes before", value="15"),
+            discord.SelectOption(label="5 minutes before", value="5"),
         ]
 
 
@@ -298,7 +298,7 @@ class EventCreationView(discord.ui.View):
         self.selected_roles = [role.name for role in select.values]
         await interaction.response.edit_message(view=self, content=f'**You selected roles:** {", ".join(self.selected_roles)}')
 
-    @discord.ui.select(cls=discord.ui.Select, placeholder='When to send reminder', options=select_offsets, min_values=0, max_values=10, row=2)
+    @discord.ui.select(cls=discord.ui.Select, placeholder='Custom remind times (default if not picked)', options=select_offsets, min_values=0, max_values=10, row=2)
     async def select_remind_times(self, interaction: discord.Interaction, select: discord.ui.Select):
         self.minute_offsets = [int(value) for value in select.values]
         await interaction.response.edit_message(view=self, content=f'**You selected offsets (in minutes):** {", ".join(select.values)}')

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -132,13 +132,6 @@ def return_valid_duration(duration: str):
     return duration_minutes if duration_minutes > 0 else False
 
 
-SELECT_OPTIONS = [
-    discord.SelectOption(label='Role0', value = "0"),
-    discord.SelectOption(label='Role1', value = "1"),
-    discord.SelectOption(label='Role2', value = "2")
-]
-
-
 class EventCreationView(discord.ui.View):
 
     def __init__(self, user: discord.User):
@@ -156,7 +149,7 @@ class EventCreationView(discord.ui.View):
             "start_time": "",
             "end_time": ""
         }
-        self.selected_roles=None
+        self.selected_roles = None
         self.name_modal_submitted = False
         self.date_modal_submitted = False
 
@@ -287,5 +280,5 @@ class EventCreationView(discord.ui.View):
 
     @discord.ui.select(cls=discord.ui.RoleSelect, placeholder='Roles to ping', min_values=0, max_values=25, row=1)
     async def select_roles(self, interaction: discord.Interaction, select: discord.ui.RoleSelect):
-        self.selected_roles=[role.name for role in select.values]
+        self.selected_roles = [role.name for role in select.values]
         await interaction.response.edit_message(view=self, content=f'**You selected roles:** {", ".join(self.selected_roles)}')

--- a/discordbot/views/event_creation_view.py
+++ b/discordbot/views/event_creation_view.py
@@ -132,6 +132,20 @@ def return_valid_duration(duration: str):
     return duration_minutes if duration_minutes > 0 else False
 
 
+select_offsets = [
+            discord.SelectOption(label="1 week before", value="10080"),  # 168 hours * 60 minutes
+            discord.SelectOption(label="3 days before", value="4320"),   # 72 hours * 60 minutes
+            discord.SelectOption(label="1 day before", value="1440"),    # 24 hours * 60 minutes
+            discord.SelectOption(label="12 hours before", value="720"),  # 12 hours * 60 minutes
+            discord.SelectOption(label="6 hours before", value="360"),   # 6 hours * 60 minutes
+            discord.SelectOption(label="3 hours before", value="180"),   # 3 hours * 60 minutes
+            discord.SelectOption(label="1 hour before", value="60"),     # 1 hour * 60 minutes
+            discord.SelectOption(label="30 minutes before", value="30"), # 30 minutes
+            discord.SelectOption(label="15 minutes before", value="15"), # 15 minutes
+            discord.SelectOption(label="5 minutes before", value="5"),   # 5 minutes
+        ]
+
+
 class EventCreationView(discord.ui.View):
 
     def __init__(self, user: discord.User):
@@ -150,6 +164,7 @@ class EventCreationView(discord.ui.View):
             "end_time": ""
         }
         self.selected_roles = None
+        self.minute_offsets = None
         self.name_modal_submitted = False
         self.date_modal_submitted = False
 
@@ -282,3 +297,8 @@ class EventCreationView(discord.ui.View):
     async def select_roles(self, interaction: discord.Interaction, select: discord.ui.RoleSelect):
         self.selected_roles = [role.name for role in select.values]
         await interaction.response.edit_message(view=self, content=f'**You selected roles:** {", ".join(self.selected_roles)}')
+
+    @discord.ui.select(cls=discord.ui.Select, placeholder='When to send reminder', options=select_offsets, min_values=0, max_values=10, row=2)
+    async def select_remind_times(self, interaction: discord.Interaction, select: discord.ui.Select):
+        self.minute_offsets = [int(value) for value in select.values]
+        await interaction.response.edit_message(view=self, content=f'**You selected offsets (in minutes):** {", ".join(select.values)}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
+APScheduler==3.10.4
 discord.py==2.3.2
-python-dotenv==1.0.0
-google-api-python-client==2.108.0
-google-auth-httplib2==0.1.1
-google-auth-oauthlib==1.1.0
+google_api_python_client==2.118.0
+google_auth_oauthlib==1.2.0
+protobuf==4.25.3
+python-dotenv==1.0.1
+pytz==2024.1


### PR DESCRIPTION
## googlecalendar.py

This cog is now responsible for scheduling when to send a reminder for each event and sending those reminders to a specified channel (set with **!setreminderchannel** channel_id).

Every time an event is created with **!plan**, custom reminder times can be specified. If not specified, uses default reminder times. Default reminder times are - 1 day before event, 3 hours before event, 15 minutes before event, but can be changed with **!setdefaultremindertimes** (sends a menu). Additionally, roles to ping can be selected when using the **!plan** creation menu.

Reminder times for an event get stored as offsets in minutes. e.g. [60, 30, 15] means a reminder for an event will be sent 60 minutes before it begins, 30 minutes, 15 minutes. Order does not matter.

Cog workflow:
1. Constructor gets initialized, reminder_channel_id and default_reminders_mins get loaded from a json file. If json file does not exist, it gets created with default values, and the default value for reminder_channel_id is Null.
2. schedule_reminders task starts, getting events from google_calendar_api every hour. Custom ones are gotten separately because they are reminded of earlier - a week away for example. Therefore just getting 15 closest events would be risky.
3. schedule_reminders checks whether an event_id is in the scheduled_events set. If it isn't, schedule_event_reminder gets called and the scheduler gets a job added for when to send each reminder for a particular event, and to remove the event_id from scheduled_events when the event ends.
4. At each specific remind time, send_reminder gets called, sending the reminder in the channel with the id reminder_channel_id. If an event has roles to ping stored in 'privateExtendedPropeties.roles', they are pinged with the reminder. If there is a role that the bot couldn't make mentionable it just gets ignored.

## google_calendar_api.py

If an event is created with **!plan** and has custom reminder times and/or roles to ping with a reminder - they are stored inside the event's json in 'privateExtendedProperties'.


closes #18

